### PR TITLE
Fixes for minor errors in PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,17 @@ The reason is that monolithic files are poor candidates for version control make
         textpack.txp          - Textpack file (optional)
         help.textile          - Textile formatted help (optional, recommended)
         help.help             - HTML formatted help (optional)
+        data.txp              - Included resources (optional)
 ```
 
 3. Write your plugin!
 
-4. Execute the package tool, specifying the path to the plugin; it will output a text file appropriately encoded, based on the plugin name and version in the manifest. For example:
+4. Execute the package tool, specifying the path to the plugin; it will output a text file appropriately encoded, based on the plugin name and version in the manifest. If desired, you may specify an output filename and location:
+```
+   php ais_txpplugin_packager.php <plugin_path> [<output_file>]
+```
+
+For example:
 ```
    php ais_txpplugin_packager.php /var/www/txp/sites/dev/admin/plugins/xxx_plugin_name
 ```

--- a/ais_txpplugin_packager.php
+++ b/ais_txpplugin_packager.php
@@ -157,7 +157,7 @@ if (isset($manifest['order'])) {
     echo ('             Order: ' . $manifest['order'] . "\n");
 }
 echo ('              Type: ' . $manifest['type'] . ' (' . pluginTypeString(intval($manifest['type'])). ")\n");
-echo ('             Flags: ' . $manifest['flags'] . ' (' . pluginFlagsString(intval($manifest['type'])). ")\n");
+echo ('             Flags: ' . $manifest['flags'] . ' (' . pluginFlagsString(intval($manifest['flags'])). ")\n");
 
 
 /* ********************************************************************************** */

--- a/ais_txpplugin_packager.php
+++ b/ais_txpplugin_packager.php
@@ -126,11 +126,11 @@ function pluginFlagsString(int $flags): string
     $flagArray = [];
     
     if ($flags & $PLUGIN_HAS_PREFS) {
-	$flagArray .= 'HAS_PREFS';
+	$flagArray[] = 'HAS_PREFS';
     }
-    
+
     if ($flags & $PLUGIN_LIFECYCLE_NOTIFY) {
-	$flagArray .= 'LIFECYCLE_NOTIFY';
+	$flagArray[] = 'LIFECYCLE_NOTIFY';
     }
     
     if (empty($flagArray)) {


### PR DESCRIPTION
Three minor suggested fixes:

- With PHP 8.3 I get an "array to string conversion" error in the descriptive text output for the plugin flags.
- It was not actually retrieving the flags integer but the type integer. 
- Minor readme additions to include data.txp and ability to optionally specify an output file 